### PR TITLE
[FEAT] routine update시 sticker stamp 변경 #13

### DIFF
--- a/src/routines/entities/routine.entity.ts
+++ b/src/routines/entities/routine.entity.ts
@@ -3,7 +3,6 @@ import { User } from 'src/users/entities/user.entity';
 import {
   Column,
   Entity,
-  JoinColumn,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -17,10 +16,9 @@ export class Routine {
   @Field(() => Int)
   id: number;
 
-  @JoinColumn({ name: 'userId' })
   @Field(() => User)
   @ManyToOne(() => User, (user) => user.routines, { onDelete: 'CASCADE' })
-  userId: User;
+  user: User;
 
   @Field(() => StickerStamp)
   @OneToMany(() => StickerStamp, (stickerStamps) => stickerStamps.routineId, {

--- a/src/routines/routines.service.ts
+++ b/src/routines/routines.service.ts
@@ -47,7 +47,7 @@ export class RoutinesService {
 
   findOne(id: number) {
     return this.routinesRepository.findOne(id, {
-      relations: ['user', 'stickerStamps'],
+      relations: ['user'],
     });
   }
 

--- a/src/routines/routines.service.ts
+++ b/src/routines/routines.service.ts
@@ -49,15 +49,23 @@ export class RoutinesService {
     return this.routinesRepository.findOne(id);
   }
 
+  async findRoutine(id: number) {
+    const routine = await this.routinesRepository.query(
+      `SELECT * FROM routinder.routine WHERE id=${id}`,
+    );
+    return routine[0];
+  }
+
   async update(
     id: number,
     updateRoutineInput: UpdateRoutineInput,
   ): Promise<Routine> {
-    let routine = await this.routinesRepository.findOne(id);
+    let routine = await this.findRoutine(id);
     routine = { ...routine, ...updateRoutineInput };
     if (this.validateDate(routine) instanceof Error)
       throw new Error(this.validateDate(routine).message);
-    await this.routinesRepository.save(routine);
+    const savedRoutine = await this.routinesRepository.save(routine);
+    this.stickerStampsService.update(savedRoutine);
     return this.routinesRepository.findOne(id);
   }
 

--- a/src/routines/routines.service.ts
+++ b/src/routines/routines.service.ts
@@ -46,21 +46,16 @@ export class RoutinesService {
   }
 
   findOne(id: number) {
-    return this.routinesRepository.findOne(id);
-  }
-
-  async findRoutine(id: number) {
-    const routine = await this.routinesRepository.query(
-      `SELECT * FROM routinder.routine WHERE id=${id}`,
-    );
-    return routine[0];
+    return this.routinesRepository.findOne(id, {
+      relations: ['user', 'stickerStamps'],
+    });
   }
 
   async update(
     id: number,
     updateRoutineInput: UpdateRoutineInput,
   ): Promise<Routine> {
-    let routine = await this.findRoutine(id);
+    let routine = await this.findOne(id);
     routine = { ...routine, ...updateRoutineInput };
     if (this.validateDate(routine) instanceof Error)
       throw new Error(this.validateDate(routine).message);

--- a/src/sticker-stamps/sticker-stamps.service.ts
+++ b/src/sticker-stamps/sticker-stamps.service.ts
@@ -75,7 +75,7 @@ export class StickerStampsService {
     return interval;
   }
 
-  async create(routine: Routine) {
+  daysToStickerStamp(routine: Routine) {
     //startDate 랑 endDate로 일자계산해서 [{ userId: 1, routineId: 1, when: 2021-02-01 00:00:00 }, ..]
     const { userId, id, startDate, endDate, days } = { ...routine };
     let startTim = startDate.getTime();
@@ -94,6 +94,9 @@ export class StickerStampsService {
     while (strtIdx < daysToNum.length) {
       if (today < daysToNum[strtIdx]) {
         interval.push(daysToNum[strtIdx] - today);
+        break;
+      } else if (today === daysToNum[strtIdx]) {
+        interval.push(0);
         break;
       }
       strtIdx++;
@@ -132,6 +135,12 @@ export class StickerStampsService {
       stampsInfo.push(stampInfo);
       strtIdx++;
     }
+    console.log(stampsInfo);
+    return stampsInfo;
+  }
+
+  async create(routine: Routine) {
+    const stampsInfo = this.daysToStickerStamp(routine);
 
     await this.StickerStampsRepository.createQueryBuilder()
       .insert()
@@ -140,5 +149,22 @@ export class StickerStampsService {
       .execute();
 
     console.log('StickerStamps Successfully created');
+  }
+
+  async update(routine: Routine) {
+    const { id } = { ...routine };
+    const stampsInfo = this.daysToStickerStamp(routine);
+    await this.StickerStampsRepository.createQueryBuilder()
+      .delete()
+      .from('sticker_stamp')
+      .where('routineId = :routineId', { routineId: id })
+      .execute();
+    await this.StickerStampsRepository.createQueryBuilder()
+      .insert()
+      .into('sticker_stamp')
+      .values(stampsInfo)
+      .execute();
+
+    console.log('StickerStamps Successfully updated');
   }
 }

--- a/src/sticker-stamps/sticker-stamps.service.ts
+++ b/src/sticker-stamps/sticker-stamps.service.ts
@@ -48,7 +48,7 @@ export class StickerStampsService {
     const { user, id, startDate, endDate, days } = { ...routine };
     let startTim = startDate.getTime();
     const endTim = endDate.getTime();
-    const stampsInfo = [];
+    const stamps = [];
 
     const today = startDate.getDay();
     const standard = [0, 1, 2, 3, 4, 5, 6]; //[0 일,1 월,2 화,3 수,4 목,5 금,6 토]
@@ -93,12 +93,12 @@ export class StickerStampsService {
 
     //4. 시작날짜 세팅해주고 첫 인덱스는 삭제
     startTim += 1000 * 60 * 60 * 24 * interval[0];
-    const stampInfo = {
+    const stamp = {
       userId: user.id,
       routineId: id,
       when: new Date(startTim),
     };
-    stampsInfo.push(stampInfo);
+    stamps.push(stamp);
     interval.shift();
 
     //5. 일자간격 더해주면서 스티커스탬프 생성, strtIdx 가 interval.length 이면 0으로 초기화
@@ -108,33 +108,31 @@ export class StickerStampsService {
       }
       startTim += 1000 * 60 * 60 * 24 * interval[strtIdx];
       const startDate = new Date(startTim);
-      const stampInfo = {
+      const stamp = {
         userId: user.id,
         routineId: id,
         when: startDate,
       };
-      stampsInfo.push(stampInfo);
+      stamps.push(stamp);
       strtIdx++;
     }
-    console.log(stampsInfo);
-    return stampsInfo;
+
+    return stamps;
   }
 
   async create(routine: Routine) {
-    const stampsInfo = this.daysToStickerStamp(routine);
+    const stamps = this.daysToStickerStamp(routine);
 
     await this.StickerStampsRepository.createQueryBuilder()
       .insert()
       .into('sticker_stamp')
-      .values(stampsInfo)
+      .values(stamps)
       .execute();
-
-    console.log('StickerStamps Successfully created');
   }
 
   async update(routine: Routine) {
     const { id } = { ...routine };
-    const stampsInfo = this.daysToStickerStamp(routine);
+    const stamps = this.daysToStickerStamp(routine);
     await this.StickerStampsRepository.createQueryBuilder()
       .delete()
       .from('sticker_stamp')
@@ -143,9 +141,7 @@ export class StickerStampsService {
     await this.StickerStampsRepository.createQueryBuilder()
       .insert()
       .into('sticker_stamp')
-      .values(stampsInfo)
+      .values(stamps)
       .execute();
-
-    console.log('StickerStamps Successfully updated');
   }
 }

--- a/src/sticker-stamps/sticker-stamps.service.ts
+++ b/src/sticker-stamps/sticker-stamps.service.ts
@@ -44,83 +44,64 @@ export class StickerStampsService {
     return await this.StickerStampsRepository.findOne(id);
   }
 
-  //days '0123456' '1, 3, 5'
-  //daysToNum = [0 일,1 월,2 화,3 수,4 목,5 금,6 토] [1, 3, 6] 오늘이 4 목요일일 때 일단 토
-  //interval = [2, 2, 2]
-  countInterval(today: number, days: string) {
-    const standard = [0, 1, 2, 3, 4, 5, 6];
-    const daysToNum = [];
-    const interval = [];
-    for (let i = 0; i < days.length; i++) {
-      daysToNum.push(+days[i]);
-    }
-    //[1, 3, 5, 6]이고 오늘이 4라고 치면 strtIdx는 2겠지?
-    let strtIdx = 0;
-    while (strtIdx < daysToNum.length) {
-      if (today < daysToNum[strtIdx]) {
-        interval.push(daysToNum[strtIdx] - today);
-        break;
-      }
-      strtIdx++;
-    }
-    // daysToNum = [1, 3, 6]; 이게 지금 토탈 토요일부터 월요일까지 이틀이지 [1, 3, 5] 면 금욜부터 월욜까지 삼일
-    const lstToZero = Math.abs(daysToNum[daysToNum.length - 1] - 6) + 1;
-    const zeroToStrt = standard.findIndex((elem) => elem === daysToNum[0]); // 1
-
-    interval.push(lstToZero + zeroToStrt);
-    for (let i = 1; i < daysToNum.length - 1; i++) {
-      interval.push(daysToNum[i] - daysToNum[i - 1]);
-    }
-
-    return interval;
-  }
-
   daysToStickerStamp(routine: Routine) {
-    //startDate 랑 endDate로 일자계산해서 [{ userId: 1, routineId: 1, when: 2021-02-01 00:00:00 }, ..]
-    const { userId, id, startDate, endDate, days } = { ...routine };
+    const { user, id, startDate, endDate, days } = { ...routine };
     let startTim = startDate.getTime();
     const endTim = endDate.getTime();
     const stampsInfo = [];
 
     const today = startDate.getDay();
-    const standard = [0, 1, 2, 3, 4, 5, 6];
-    const daysToNum = [];
-    const interval = [];
+    const standard = [0, 1, 2, 3, 4, 5, 6]; //[0 일,1 월,2 화,3 수,4 목,5 금,6 토]
+    const daysToNum = []; //루틴 요일
+    const interval = []; //일자 간격
     for (let i = 0; i < days.length; i++) {
       daysToNum.push(+days[i]);
     }
-    //[1, 3, 5, 6]이고 오늘이 4라고 치면 strtIdx는 2겠지?
+
+    //1. startDate와 가장 가까운 요일을 찾아 차이를 계산해 interval에 삽입, strtIdx 값 세팅
     let strtIdx = 0;
     while (strtIdx < daysToNum.length) {
+      // 1) 오늘이 루틴 요일보다 큰 경우 ex. [1, 3, 5] 인데 오늘이 6인 경우
+      if (today > Math.max.apply(null, daysToNum)) {
+        const lstToZero = Math.abs(today - 6) + 1;
+        const zeroToStrt = standard.findIndex((elem) => elem === daysToNum[0]);
+        interval.push(lstToZero + zeroToStrt);
+        break;
+      }
+      // 2) 오늘이 루틴 중간에 껴있는 경우 ex. [1, 3, 5]인데 오늘이 4인 경우
       if (today < daysToNum[strtIdx]) {
         interval.push(daysToNum[strtIdx] - today);
         break;
-      } else if (today === daysToNum[strtIdx]) {
+      }
+      // 3) 오늘이 루틴날인 경우 ex. [1, 3, 5]인데 오늘이 3인 경우
+      else if (today === daysToNum[strtIdx]) {
         interval.push(0);
         break;
       }
       strtIdx++;
     }
 
+    //2. interval에 요일 간격 일자를 삽입
     for (let i = 1; i < daysToNum.length; i++) {
       interval.push(daysToNum[i] - daysToNum[i - 1]);
     }
-    // daysToNum = [1, 3, 6]; 이게 지금 토탈 토요일부터 월요일까지 이틀이지 [1, 3, 5] 면 금욜부터 월욜까지 삼일
+
+    //3. 루틴의 마지막 요일과 시작 요일의 차이를 계산해 interval에 삽입
     const lstToZero = Math.abs(daysToNum[daysToNum.length - 1] - 6) + 1;
     const zeroToStrt = standard.findIndex((elem) => elem === daysToNum[0]);
     interval.push(lstToZero + zeroToStrt);
 
-    //days 만큼 생성해야되네;
+    //4. 시작날짜 세팅해주고 첫 인덱스는 삭제
     startTim += 1000 * 60 * 60 * 24 * interval[0];
     const stampInfo = {
-      userId,
+      userId: user.id,
       routineId: id,
       when: new Date(startTim),
     };
     stampsInfo.push(stampInfo);
     interval.shift();
 
-    //strtIdx 가 interval.length 이면 0으로 다시 초기화시켜
+    //5. 일자간격 더해주면서 스티커스탬프 생성, strtIdx 가 interval.length 이면 0으로 초기화
     while (startTim < endTim) {
       if (strtIdx === interval.length) {
         strtIdx = 0;
@@ -128,7 +109,7 @@ export class StickerStampsService {
       startTim += 1000 * 60 * 60 * 24 * interval[strtIdx];
       const startDate = new Date(startTim);
       const stampInfo = {
-        userId,
+        userId: user.id,
         routineId: id,
         when: startDate,
       };

--- a/src/sticker-stamps/sticker-stamps.service.ts
+++ b/src/sticker-stamps/sticker-stamps.service.ts
@@ -21,12 +21,12 @@ export class StickerStampsService {
   async findByDate(id: number, after?: Date, before?: Date) {
     return await this.StickerStampsRepository.createQueryBuilder('stamp')
       .innerJoinAndMapOne(
-        'stamp.routine',
+        'stamp.routineId',
         Routine,
-        'routine',
-        'stamp.routineId = routine.id',
+        'routineId',
+        'stamp.routineId = routineId.id',
       )
-      .where('routine.userId = :userId', { userId: id })
+      .where('routineId.userId = :userId', { userId: id })
       .andWhere('stamp.when >= :start', { start: after })
       .andWhere('stamp.when <= :end', { end: before })
       .getMany();

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -11,7 +11,7 @@ export class User {
   id: number;
 
   @Field(() => [Routine], { nullable: true })
-  @OneToMany(() => Routine, (routine) => routine.userId, {
+  @OneToMany(() => Routine, (routine) => routine.user, {
     cascade: true,
   })
   routines: Routine[];

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -1,17 +1,10 @@
-import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
-import { UsersService } from './users.service';
+import { Args, Int, Query, Resolver } from '@nestjs/graphql';
 import { User } from './entities/user.entity';
-import { CreateUserInput } from './dto/create-user.input';
-import { UpdateUserInput } from './dto/update-user.input';
+import { UsersService } from './users.service';
 
 @Resolver(() => User)
 export class UsersResolver {
   constructor(private readonly usersService: UsersService) {}
-
-  // @Mutation(() => User)
-  // createUser(@Args('createUserInput') createUserInput: CreateUserInput) {
-  //   return this.usersService.create(createUserInput);
-  // }
 
   @Query(() => [User], { name: 'users' })
   findAll() {
@@ -22,14 +15,4 @@ export class UsersResolver {
   findOne(@Args('id', { type: () => Int }) id: number) {
     return this.usersService.findOne(id);
   }
-
-  // @Mutation(() => User)
-  // updateUser(@Args('updateUserInput') updateUserInput: UpdateUserInput) {
-  //   return this.usersService.update(updateUserInput.id, updateUserInput);
-  // }
-
-  // @Mutation(() => User)
-  // removeUser(@Args('id', { type: () => Int }) id: number) {
-  //   return this.usersService.remove(id);
-  // }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,32 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CreateUserInput } from './dto/create-user.input';
-import { UpdateUserInput } from './dto/update-user.input';
 import { User } from './entities/user.entity';
-
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(User) private usersRepository: Repository<User>,
   ) {}
-  // create(createUserInput: CreateUserInput) {
-  //   return 'This action adds a new user';
-  // }
 
   findAll(): Promise<User[]> {
     return this.usersRepository.find();
   }
 
-  findOne(id: number): Promise<User> {
-    return this.usersRepository.findOneOrFail(id);
+  async findOne(id: number) {
+    return this.usersRepository.findOne(id, {
+      relations: ['routines', 'stickerStamps'],
+    });
   }
-
-  // update(id: number, updateUserInput: UpdateUserInput) {
-  //   return `This action updates a #${id} user`;
-  // }
-
-  // remove(id: number) {
-  //   return `This action removes a #${id} user`;
-  // }
 }


### PR DESCRIPTION
### Issue Number 

close: #11 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] days를 sticker stamp로 넣는 로직 예외처리
- [x] routine 조회시 userId가 조회되지 않는 문제 임시로 raw query로 해결 => findOne에 relation 옵션 추가해서 해결함!
- [x] stickerStamp entity를 제외한 나머지 entity는 원복 

### 변경사항

- days를 sticker stamp로 넣는 로직 예외처리. days 로 등록한 요일이 오늘일 때, 오늘부터 시작할 수 있도록 변경
- routine 조회시 userId가 조회되지 않는 문제 임시로 raw query로 해결. => findOne에 relation 옵션 추가해서 해결함!
- stickerStamp entity를 제외한 나머지 entity는 원복 

### 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점


