### PR TITLE
[Feat] Routine 등록 최대 갯수 설정

### DIFF
--- a/src/routines/entities/routine.entity.ts
+++ b/src/routines/entities/routine.entity.ts
@@ -3,6 +3,7 @@ import { User } from 'src/users/entities/user.entity';
 import {
   Column,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -16,9 +17,10 @@ export class Routine {
   @Field(() => Int)
   id: number;
 
+  @JoinColumn({ name: 'userId' })
   @Field(() => User)
-  @ManyToOne(() => User, (user) => user.routines, { onDelete: 'CASCADE' })
-  user: User;
+  @ManyToOne(() => User, (user) => user.stickerStamps, { onDelete: 'CASCADE' })
+  userId: User;
 
   @Field(() => StickerStamp)
   @OneToMany(() => StickerStamp, (stickerStamps) => stickerStamps.routineId, {

--- a/src/routines/routines.service.ts
+++ b/src/routines/routines.service.ts
@@ -32,7 +32,7 @@ export class RoutinesService {
       return new Error('Invalid Days');
   }
 
-  async activeRoutines(routine: Routine) {
+  async getActiveRoutines(routine: Routine) {
     const currentDate = new Date();
     const [emptyArr, cnt] = await this.routinesRepository
       .createQueryBuilder('routine')
@@ -48,7 +48,7 @@ export class RoutinesService {
     const newRoutine = this.routinesRepository.create(createRoutineInput);
     if (this.validateDate(newRoutine) instanceof Error)
       throw new Error(this.validateDate(newRoutine).message);
-    if ((await this.activeRoutines(newRoutine)) > 10)
+    if ((await this.getActiveRoutines(newRoutine)) > 10)
       throw new Error('Max 10 routines can be registered');
 
     const savedRoutine = await this.routinesRepository.save(newRoutine);

--- a/src/sticker-stamps/sticker-stamps.service.ts
+++ b/src/sticker-stamps/sticker-stamps.service.ts
@@ -45,7 +45,7 @@ export class StickerStampsService {
   }
 
   daysToStickerStamp(routine: Routine) {
-    const { user, id, startDate, endDate, days } = { ...routine };
+    const { userId, id, startDate, endDate, days } = { ...routine };
     let startTim = startDate.getTime();
     const endTim = endDate.getTime();
     const stamps = [];
@@ -94,7 +94,7 @@ export class StickerStampsService {
     //4. 시작날짜 세팅해주고 첫 인덱스는 삭제
     startTim += 1000 * 60 * 60 * 24 * interval[0];
     const stamp = {
-      userId: user.id,
+      userId,
       routineId: id,
       when: new Date(startTim),
     };
@@ -109,7 +109,7 @@ export class StickerStampsService {
       startTim += 1000 * 60 * 60 * 24 * interval[strtIdx];
       const startDate = new Date(startTim);
       const stamp = {
-        userId: user.id,
+        userId,
         routineId: id,
         when: startDate,
       };

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -11,7 +11,7 @@ export class User {
   id: number;
 
   @Field(() => [Routine], { nullable: true })
-  @OneToMany(() => Routine, (routine) => routine.user, {
+  @OneToMany(() => Routine, (routine) => routine.userId, {
     cascade: true,
   })
   routines: Routine[];


### PR DESCRIPTION
### Issue Number 

close: #18 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] routine entity column 수정
- [x] active Routine 갯수 제한

### 변경사항

- routine 생성 시 userId가 insert 되지 않는 문제로 entity를 수정
- routine 생성 시 현재 active한 routine 갯수가 10개를 초과하면 등록하지 않고 에러를 리턴하도록 수정

### 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 없습니다.

