### PR TITLE
feat    : oauth 로그인 set-cookie, credentials 추가 (#15)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalFilters(new AllExceptionsFilter());
   app.useGlobalPipes(new ValidationPipe());
-  app.enableCors();
+  app.enableCors({ origin: process.env.CLIENT_IP, credentials: true });
   await app.listen(3001);
 }
 bootstrap();

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Res } from '@nestjs/common';
+import { Response } from 'express';
 import { OauthService } from './oauth.service';
 
 @Controller('oauth')
@@ -6,16 +7,24 @@ export class OauthController {
   constructor(private readonly oauthService: OauthService) {}
 
   @Post('github')
-  async githubLogin(@Body() body): Promise<{ token: string }> {
+  async githubLogin(
+    @Body() body,
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<{ token: string }> {
     const { data } = body;
     const jwtToken = this.oauthService.githubLogin(data.code);
+    response.cookie('jwtToken', jwtToken, { httpOnly: true });
     return jwtToken;
   }
 
   @Post('google')
-  async googleLogin(@Body() body): Promise<{ token: string }> {
+  async googleLogin(
+    @Body() body,
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<{ token: string }> {
     const { data } = body;
     const jwtToken = this.oauthService.googleLogin(data.code);
+    response.cookie('jwtToken', jwtToken, { httpOnly: true });
     return jwtToken;
   }
 }

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -10,21 +10,21 @@ export class OauthController {
   async githubLogin(
     @Body() body,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<{ token: string }> {
+  ): Promise<string> {
     const { data } = body;
-    const jwtToken = this.oauthService.githubLogin(data.code);
-    response.cookie('jwtToken', jwtToken, { httpOnly: true });
-    return jwtToken;
+    const { token } = await this.oauthService.githubLogin(data.code);
+    response.cookie('jwtToken', token, { httpOnly: true });
+    return token;
   }
 
   @Post('google')
   async googleLogin(
     @Body() body,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<{ token: string }> {
+  ): Promise<string> {
     const { data } = body;
-    const jwtToken = this.oauthService.googleLogin(data.code);
-    response.cookie('jwtToken', jwtToken, { httpOnly: true });
-    return jwtToken;
+    const { token } = await this.oauthService.githubLogin(data.code);
+    response.cookie('jwtToken', token, { httpOnly: true });
+    return token;
   }
 }

--- a/src/oauth/oauth.service.ts
+++ b/src/oauth/oauth.service.ts
@@ -8,7 +8,7 @@ const GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 const GITHUB_USER_URL = 'https://api.github.com/user';
 const REDIRECT_URI = 'http://localhost:3000';
 const GOOGLE_ACCESS_TOKEN_URL = 'https://accounts.google.com/o/oauth2/token';
-const GOOGLE_REDIRECT_URI = 'http://localhost:3000/ggl-login-callback';
+const GOOGLE_REDIRECT_URI = 'http://localhost:3000/login-callback';
 @Injectable()
 export class OauthService {
   constructor(


### PR DESCRIPTION
### Issue Number 

close: #15 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 응답에 httpOnly set-cookie 헤더 추가
- [x] 클라이언트 URL CORS에 추가

### 변경사항

- .env 수정이 있습니다 (클라 URL 추가)

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- 쿠키는 서버에서 세팅이 필요하여 수정이 있었습니다.
- credential 추가가 필요한 경우 CORS 를 wild-card (*) 로 지정할 수 없어 직접적인 url 명시가 필요합니다. 

